### PR TITLE
Revert "Bump bats version to v1.14.0"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ listgroup-%: check-reqs
 
 # Ensure bats exists in the current folder
 bats:
-	git clone --branch v1.14.0 https://github.com/bats-core/bats-core ./bats
+	git clone --branch v1.13.0 https://github.com/bats-core/bats-core ./bats
 
 # Ensure all bats submodules are up to date
 prepare-test: bats check-reqs target
@@ -151,7 +151,7 @@ publish-%: target show-%
 
 ## Define bats options based on environment
 # common flags for all tests
-bats_flags := --formatter pretty
+bats_flags := ""
 # if DISABLE_PARALLEL_TESTS true, then disable parallel execution
 ifneq (true,$(DISABLE_PARALLEL_TESTS))
 # If the GNU 'parallel' command line is absent, then disable parallel execution
@@ -193,11 +193,10 @@ _test-image:
 # Each type of image ("agent" or "inbound-agent") has its own tests suite
 ifeq ($(CI), true)
 # Execute the test harness and write result to a TAP file
-	IMAGE=$(TARGET) bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $(TARGET) |  cut -d "_" -f 1).bats $(bats_flags) --report-formatter junit --output target/ | tee target/junit-results-$(TARGET).xml
-	mv target/report.xml target/junit-results-$(TARGET).xml
+	IMAGE=$(TARGET) bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $(TARGET) |  cut -d "_" -f 1).bats $(bats_flags) --formatter junit | tee target/junit-results-$(TARGET).xml
 else
 # Execute the test harness
-	IMAGE=$(TARGET) bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $(TARGET) |  cut -d "_" -f 1).bats $(bats_flags) --timing
+	IMAGE=$(TARGET) bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $(TARGET) |  cut -d "_" -f 1).bats $(bats_flags) --formatter pretty --timing
 endif
 
 # Test all targets depending on the current OS and architecture


### PR DESCRIPTION
Reverts jenkinsci/docker-agents#1261 to allow releasing new remoting.

Caused #1296, will rework that upgrade afterward.

Ref:
- https://github.com/jenkinsci/docker-agents/issues/1296#issuecomment-5264568695