### PR TITLE
chore(updatecli) fix JDK manifests with missing windows lines JDK version in target patterns

### DIFF
--- a/updatecli/updatecli.d/jdk21.yaml
+++ b/updatecli/updatecli.d/jdk21.yaml
@@ -45,7 +45,7 @@ targets:
     {{- $adoptiumOS := index (splitList "/" $platform) 0 }}
     {{- $adoptiumCPU := index (splitList "/" $platform) 1 }}
     {{- $dockerCPU := ( eq $adoptiumCPU "x64" | ternary "amd64" ( eq $adoptiumCPU "aarch64" | ternary "arm64" $adoptiumCPU )) }}
-    {{- $prefix := "windows/amd64" }}
+    {{- $prefix := printf "jdk%d/%s/%s" $jdkRelease "windows" "amd64" }}
     {{- if ne $adoptiumOS "windows" }}
       {{- $prefix = printf "jdk%d/linux/%s/%s" $jdkRelease $dockerCPU (eq $adoptiumOS "alpine-linux" | ternary "musl" "glibc" )}}
     {{- end }}

--- a/updatecli/updatecli.d/jdk25.yaml
+++ b/updatecli/updatecli.d/jdk25.yaml
@@ -45,7 +45,7 @@ targets:
     {{- $adoptiumOS := index (splitList "/" $platform) 0 }}
     {{- $adoptiumCPU := index (splitList "/" $platform) 1 }}
     {{- $dockerCPU := ( eq $adoptiumCPU "x64" | ternary "amd64" ( eq $adoptiumCPU "aarch64" | ternary "arm64" $adoptiumCPU )) }}
-    {{- $prefix := "windows/amd64" }}
+    {{- $prefix := printf "jdk%d/%s/%s" $jdkRelease "windows" "amd64" }}
     {{- if ne $adoptiumOS "windows" }}
       {{- $prefix = printf "jdk%d/linux/%s/%s" $jdkRelease $dockerCPU (eq $adoptiumOS "alpine-linux" | ternary "musl" "glibc" )}}
     {{- end }}


### PR DESCRIPTION
Fixup of #1280 and #1281. I'm not sure why my local test did not fail like the borked PRs #1305 and #1306. Most probably I forgot to verify with Windows 😮‍💨 

Closes #1305 and #1306 

### Testing done

- Local tests with the `scmid` commented with `updatecli` (0.120.0)
  - From the tip of `upstream/main`, a change is proposed on both windows line, mapping to the behavior we see in #1305 #1306
  - With this fix: no changes proposed to the local installer list for both manifests.

- CI: the GHA run shows no changes for both JDKs:
  - JDK21: https://github.com/jenkinsci/docker-agents/actions/runs/31779702083/job/94702573411?pr=1308#step:4:882
  - JDK25: https://github.com/jenkinsci/docker-agents/actions/runs/31779702083/job/94702573411?pr=1308#step:4:912


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
