### PR TITLE
chore(test) Bump bats version to `v1.14.0`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,7 +123,7 @@ def parallelStages = [failFast: false]
                                 } else {
                                     powershell './make.ps1 test'
                                 }
-                                junit(allowEmptyResults: false, keepLongStdio: true, testResults: 'target/**/junit-results*.xml')
+                                junit 'target/**/junit-results*.xml'
                             }
                             archiveArtifacts artifacts: 'target/build-result-metadata_*.json', allowEmptyArchive: true
                         }

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ publish-%: target show-%
 
 ## Define bats options based on environment
 # common flags for all tests
-bats_flags := --formatter pretty
+bats_flags :=
 # if DISABLE_PARALLEL_TESTS true, then disable parallel execution
 ifneq (true,$(DISABLE_PARALLEL_TESTS))
 # If the GNU 'parallel' command line is absent, then disable parallel execution
@@ -189,7 +189,7 @@ _test-group:
 _test-image:
 	@echo "Testing $(TARGET)"
 # Show bats version
-	@set -x; bats/bin/bats --version
+	@bats/bin/bats --version
 # Each type of image ("agent" or "inbound-agent") has its own tests suite
 ifeq ($(CI), true)
 # Execute the test harness and write result to a TAP file
@@ -197,7 +197,7 @@ ifeq ($(CI), true)
 	mv target/report.xml target/junit-results-$(TARGET).xml
 else
 # Execute the test harness
-	IMAGE=$(TARGET) bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $(TARGET) |  cut -d "_" -f 1).bats $(bats_flags) --timing
+	IMAGE=$(TARGET) bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $(TARGET) |  cut -d "_" -f 1).bats $(bats_flags) --formatter pretty --timing
 endif
 
 # Test all targets depending on the current OS and architecture

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ listgroup-%: check-reqs
 
 # Ensure bats exists in the current folder
 bats:
-	git clone --branch v1.13.0 https://github.com/bats-core/bats-core ./bats
+	git clone --branch v1.14.0 https://github.com/bats-core/bats-core ./bats
 
 # Ensure all bats submodules are up to date
 prepare-test: bats check-reqs target
@@ -151,7 +151,7 @@ publish-%: target show-%
 
 ## Define bats options based on environment
 # common flags for all tests
-bats_flags := ""
+bats_flags := --formatter pretty
 # if DISABLE_PARALLEL_TESTS true, then disable parallel execution
 ifneq (true,$(DISABLE_PARALLEL_TESTS))
 # If the GNU 'parallel' command line is absent, then disable parallel execution
@@ -193,10 +193,11 @@ _test-image:
 # Each type of image ("agent" or "inbound-agent") has its own tests suite
 ifeq ($(CI), true)
 # Execute the test harness and write result to a TAP file
-	IMAGE=$(TARGET) bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $(TARGET) |  cut -d "_" -f 1).bats $(bats_flags) --formatter junit | tee target/junit-results-$(TARGET).xml
+	IMAGE=$(TARGET) bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $(TARGET) |  cut -d "_" -f 1).bats $(bats_flags) --report-formatter junit --output target/ | tee target/junit-results-$(TARGET).xml
+	mv target/report.xml target/junit-results-$(TARGET).xml
 else
 # Execute the test harness
-	IMAGE=$(TARGET) bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $(TARGET) |  cut -d "_" -f 1).bats $(bats_flags) --formatter pretty --timing
+	IMAGE=$(TARGET) bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $(TARGET) |  cut -d "_" -f 1).bats $(bats_flags) --timing
 endif
 
 # Test all targets depending on the current OS and architecture

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ _test-image:
 # Each type of image ("agent" or "inbound-agent") has its own tests suite
 ifeq ($(CI), true)
 # Execute the test harness and write result to a TAP file
-	IMAGE=$(TARGET) bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $(TARGET) |  cut -d "_" -f 1).bats $(bats_flags) --report-formatter junit --output target/ | tee target/junit-results-$(TARGET).xml
+	IMAGE=$(TARGET) bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $(TARGET) |  cut -d "_" -f 1).bats $(bats_flags) --report-formatter junit --output target/
 	mv target/report.xml target/junit-results-$(TARGET).xml
 else
 # Execute the test harness


### PR DESCRIPTION
Follow up of https://github.com/jenkinsci/docker-agents/pull/1301, this is an attempt to restore the bump of bats without breaking Linux tests

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
