### PR TITLE
chore(GHA/updatecli) bump `updatecli` to `0.120.1` through the action`v3.6.0`

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@v3.5.0
+        uses: updatecli/updatecli-action@v3.6.0
 
       - name: Run Updatecli in Dry Run mode
         run: updatecli pipeline diff --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml


### PR DESCRIPTION
Ref. https://github.com/jenkinsci/docker-agents/pull/1310#issuecomment-5293213666

See https://github.com/updatecli/updatecli-action/releases/tag/v3.6.0 and https://github.com/updatecli/updatecli/releases/tag/v0.120.1 for changelogs
