### PR TITLE
chore: use 'java relase' as a coherent naming with Adoptium API

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -3,14 +3,14 @@ variable "agent_types_to_build" {
   default = ["agent", "inbound-agent"]
 }
 
-variable "jdks_to_build" {
+variable "java_releases_to_build" {
   default = [21, 25]
 }
-variable "default_jdk" {
+variable "default_java_release" {
   default = 21
 }
 
-variable "jdks_in_preview" {
+variable "java_releases_in_preview" {
   default = []
 }
 
@@ -71,93 +71,93 @@ variable "WINDOWS_AGENT_TYPE_OVERRIDE" {
 ## Targets
 target "alpine" {
   matrix = {
-    type = agent_types_to_build
-    jdk  = jdks_to_build
+    type          = agent_types_to_build
+    java_release  = java_releases_to_build
   }
-  name       = "${type}_alpine_jdk${jdk}"
+  name       = "${type}_alpine_jdk${java_release}"
   target     = type
   dockerfile = "alpine/Dockerfile"
   context    = "."
   args = {
     ALPINE_TAG   = ALPINE_FULL_TAG
     VERSION      = REMOTING_VERSION
-    JAVA_RELEASE = jdk
+    JAVA_RELEASE = java_release
   }
-  tags      = concat(linux_tags(type, jdk, "alpine"), linux_tags(type, jdk, "alpine${ALPINE_SHORT_TAG}"))
+  tags      = concat(linux_tags(type, java_release, "alpine"), linux_tags(type, java_release, "alpine${ALPINE_SHORT_TAG}"))
   platforms = ["linux/amd64", "linux/arm64"]
 }
 
 target "debian" {
   matrix = {
-    type = agent_types_to_build
-    jdk  = jdks_to_build
+    type          = agent_types_to_build
+    java_release  = java_releases_to_build
   }
-  name       = "${type}_debian_jdk${jdk}"
+  name       = "${type}_debian_jdk${java_release}"
   target     = type
   dockerfile = "debian/Dockerfile"
   context    = "."
   args = {
     VERSION        = REMOTING_VERSION
     DEBIAN_RELEASE = DEBIAN_RELEASE
-    JAVA_RELEASE   = jdk
+    JAVA_RELEASE   = java_release
   }
-  tags      = linux_tags(type, jdk, "debian")
+  tags      = linux_tags(type, java_release, "debian")
   platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x", "linux/riscv64"]
 }
 
 target "rhel_ubi9" {
   matrix = {
-    type = agent_types_to_build
-    jdk  = jdks_to_build
+    type          = agent_types_to_build
+    java_release  = java_releases_to_build
   }
-  name       = "${type}_rhel_ubi9_jdk${jdk}"
+  name       = "${type}_rhel_ubi9_jdk${java_release}"
   target     = type
   dockerfile = "rhel/ubi9/Dockerfile"
   context    = "."
   args = {
     UBI9_TAG     = UBI9_TAG
     VERSION      = REMOTING_VERSION
-    JAVA_RELEASE = jdk
+    JAVA_RELEASE = java_release
   }
-  tags      = linux_tags(type, jdk, "rhel-ubi9")
-  platforms = rhel_ubi9_platforms(jdk)
+  tags      = linux_tags(type, java_release, "rhel-ubi9")
+  platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le"]
 }
 
 target "nanoserver" {
   matrix = {
     type            = windowsagenttypes(WINDOWS_AGENT_TYPE_OVERRIDE)
-    jdk             = jdks_to_build
+    java_release    = java_releases_to_build
     windows_version = windowsversions("nanoserver")
   }
-  name       = "${type}_nanoserver-${windows_version}_jdk${jdk}"
+  name       = "${type}_nanoserver-${windows_version}_jdk${java_release}"
   dockerfile = "windows/nanoserver/Dockerfile"
   context    = "."
   args = {
     VERSION             = REMOTING_VERSION
     WINDOWS_VERSION_TAG = windows_version
-    JAVA_RELEASE        = jdk
+    JAVA_RELEASE        = java_release
   }
   target    = type
-  tags      = windows_tags(type, jdk, "nanoserver-${windows_version}")
+  tags      = windows_tags(type, java_release, "nanoserver-${windows_version}")
   platforms = ["windows/amd64"]
 }
 
 target "windowsservercore" {
   matrix = {
     type            = windowsagenttypes(WINDOWS_AGENT_TYPE_OVERRIDE)
-    jdk             = jdks_to_build
+    java_release    = java_releases_to_build
     windows_version = windowsversions("windowsservercore")
   }
-  name       = "${type}_windowsservercore-${windows_version}_jdk${jdk}"
+  name       = "${type}_windowsservercore-${windows_version}_jdk${java_release}"
   dockerfile = "windows/windowsservercore/Dockerfile"
   context    = "."
   args = {
-    JAVA_RELEASE        = jdk
+    JAVA_RELEASE        = java_release
     VERSION             = REMOTING_VERSION
     WINDOWS_VERSION_TAG = windows_version
   }
   target    = type
-  tags      = windows_tags(type, jdk, "windowsservercore-${windows_version}")
+  tags      = windows_tags(type, java_release, "windowsservercore-${windows_version}")
   platforms = ["windows/amd64"]
 }
 
@@ -191,10 +191,10 @@ function "orgrepo" {
   result = equal("agent", agentType) ? "${REGISTRY_ORG}/${REGISTRY_REPO_AGENT}" : "${REGISTRY_ORG}/${REGISTRY_REPO_INBOUND_AGENT}"
 }
 
-# Return "true" if the jdk passed as parameter is the same as the default jdk, "false" otherwise
-function "is_default_jdk" {
-  params = [jdk]
-  result = equal(default_jdk, jdk) ? true : false
+# Return "true" if the java_release passed as parameter is the same as the default java_release, "false" otherwise
+function "is_default_java_release" {
+  params = [java_release]
+  result = equal(default_java_release, java_release) ? true : false
 }
 
 ## Specific functions
@@ -215,12 +215,6 @@ function "windowsagenttypes" {
   result = (notequal(override, "")
     ? [override]
   : agent_types_to_build)
-}
-
-# Return an array of RHEL UBI 9 platforms to use depending on the jdk passed as parameter
-function "rhel_ubi9_platforms" {
-  params = [jdk]
-  result = ["linux/amd64", "linux/arm64", "linux/ppc64le"]
 }
 
 # Return the distribution followed by a dash if it is not the default distribution
@@ -247,49 +241,49 @@ function distribution_name {
   : distribution)
 }
 
-# Return the tag suffixed by "-preview" if the jdk passed as parameter is in the jdks_in_preview list
+# Return the tag suffixed by "-preview" if the java_release passed as parameter is in the java_releases_in_preview list
 function preview_tag {
-  params = [jdk]
-  result = (contains(jdks_in_preview, jdk)
-    ? "${jdk}-preview"
-  : jdk)
+  params = [java_release]
+  result = (contains(java_releases_in_preview, java_release)
+    ? "${java_release}-preview"
+  : java_release)
 }
 
-# Return an array of tags depending on the agent type, the jdk and the Linux distribution passed as parameters
+# Return an array of tags depending on the agent type, the java_release and the Linux distribution passed as parameters
 function "linux_tags" {
-  params = [type, jdk, distribution]
+  params = [type, java_release, distribution]
   result = [
     ## All
-    # If there is a tag, add versioned tag suffixed by the jdk
-    equal(ON_TAG, "true") ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}${distribution_suffix(distribution)}-jdk${preview_tag(jdk)}" : "",
+    # If there is a tag, add versioned tag suffixed by the java_release
+    equal(ON_TAG, "true") ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}${distribution_suffix(distribution)}-jdk${preview_tag(java_release)}" : "",
 
-    # If there is a tag and if the jdk is the default one, add versioned short tag
-    equal(ON_TAG, "true") ? (is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}${distribution_suffix(distribution)}" : "") : "",
+    # If there is a tag and if the java_release is the default one, add versioned short tag
+    equal(ON_TAG, "true") ? (is_default_java_release(java_release) ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}${distribution_suffix(distribution)}" : "") : "",
 
-    # If the jdk is the default one, add distribution and latest short tags
-    is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:${distribution_name(distribution)}" : "",
-    is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:latest${distribution_suffix(distribution)}" : "",
+    # If the java_release is the default one, add distribution and latest short tags
+    is_default_java_release(java_release) ? "${REGISTRY}/${orgrepo(type)}:${distribution_name(distribution)}" : "",
+    is_default_java_release(java_release) ? "${REGISTRY}/${orgrepo(type)}:latest${distribution_suffix(distribution)}" : "",
     # Needed for the ":latest-trixie" case. For other distributions, result in the same tag as above (not an issue, deduplicated at the end)
-    is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:latest-${distribution_name(distribution)}" : "",
+    is_default_java_release(java_release) ? "${REGISTRY}/${orgrepo(type)}:latest-${distribution_name(distribution)}" : "",
 
     # Tags always added
-    "${REGISTRY}/${orgrepo(type)}:${distribution_name(distribution)}-jdk${preview_tag(jdk)}",
-    "${REGISTRY}/${orgrepo(type)}:latest-${distribution_name(distribution)}-jdk${preview_tag(jdk)}",
+    "${REGISTRY}/${orgrepo(type)}:${distribution_name(distribution)}-jdk${preview_tag(java_release)}",
+    "${REGISTRY}/${orgrepo(type)}:latest-${distribution_name(distribution)}-jdk${preview_tag(java_release)}",
     # ":jdkN" and ":latest-jdkN" short tags for the default distribution. For other distributions, result in the tags above (not an issue, deduplicated at the end)
-    "${REGISTRY}/${orgrepo(type)}:${distribution_prefix(distribution)}jdk${preview_tag(jdk)}",
-    "${REGISTRY}/${orgrepo(type)}:latest-${distribution_prefix(distribution)}jdk${preview_tag(jdk)}",
+    "${REGISTRY}/${orgrepo(type)}:${distribution_prefix(distribution)}jdk${preview_tag(java_release)}",
+    "${REGISTRY}/${orgrepo(type)}:latest-${distribution_prefix(distribution)}jdk${preview_tag(java_release)}",
   ]
 }
 
-# Return an array of tags depending on the agent type, the jdk and the flavor and version of Windows passed as parameters
+# Return an array of tags depending on the agent type, the java_release and the flavor and version of Windows passed as parameters
 function "windows_tags" {
-  params = [type, jdk, flavor_and_version]
+  params = [type, java_release, flavor_and_version]
   result = [
-    # If there is a tag, add versioned tag containing the jdk
-    equal(ON_TAG, "true") ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}-jdk${preview_tag(jdk)}-${flavor_and_version}" : "",
-    # If there is a tag and if the jdk is the default one, add versioned and short tags
-    equal(ON_TAG, "true") ? (is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}-${flavor_and_version}" : "") : "",
-    equal(ON_TAG, "true") ? (is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:${flavor_and_version}" : "") : "",
-    "${REGISTRY}/${orgrepo(type)}:jdk${preview_tag(jdk)}-${flavor_and_version}",
+    # If there is a tag, add versioned tag containing the java_release
+    equal(ON_TAG, "true") ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}-jdk${preview_tag(java_release)}-${flavor_and_version}" : "",
+    # If there is a tag and if the java_release is the default one, add versioned and short tags
+    equal(ON_TAG, "true") ? (is_default_java_release(java_release) ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}-${flavor_and_version}" : "") : "",
+    equal(ON_TAG, "true") ? (is_default_java_release(java_release) ? "${REGISTRY}/${orgrepo(type)}:${flavor_and_version}" : "") : "",
+    "${REGISTRY}/${orgrepo(type)}:jdk${preview_tag(java_release)}-${flavor_and_version}",
   ]
 }

--- a/tests/agent.Tests.ps1
+++ b/tests/agent.Tests.ps1
@@ -10,7 +10,7 @@ $GLOBAL:IMAGE_TAG = $imageItems[1]
 
 $items = $global:IMAGE_TAG.Split('-')
 # Remove the 'jdk' prefix
-$global:JAVAMAJORVERSION = $items[0].Remove(0,3)
+$global:JAVARELEASE = $items[0].Remove(0,3)
 $global:WINDOWSFLAVOR = $items[1]
 $global:WINDOWSVERSIONTAG = $items[2]
 
@@ -60,7 +60,7 @@ Describe "[$global:IMAGE_NAME] image has correct applications in the PATH" {
         $exitCode, $stdout, $stderr = Run-Program 'docker' "exec $global:CONTAINERNAME $global:CONTAINERSHELL -C `"if (`$null -eq (Get-Command java.exe -ErrorAction SilentlyContinue)) { exit -1 } else { exit 0 }`""
         $exitCode | Should -Be 0
         $exitCode, $stdout, $stderr = Run-Program 'docker' "exec $global:CONTAINERNAME $global:CONTAINERSHELL -C `"`$global:VERSION = java -version 2>&1 ; Write-Host `$global:VERSION`""
-        $stdout.Trim() | Should -Match "^openjdk version `"$global:JAVAMAJORVERSION"
+        $stdout.Trim() | Should -Match "^openjdk version `"$global:JAVARELEASE"
     }
 
     It 'has AGENT_WORKDIR in the environment' {
@@ -154,7 +154,7 @@ Describe "[$global:IMAGE_NAME] can be built with custom build arguments" {
     BeforeAll {
         Push-Location -StackName 'agent' -Path "$PSScriptRoot/.."
 
-        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --target agent --build-arg `"VERSION=${global:TEST_VERSION}`" --build-arg `"JAVA_RELEASE=${global:JAVAMAJORVERSION}`" --build-arg `"WINDOWS_VERSION_TAG=${global:WINDOWSVERSIONTAG}`" --build-arg `"user=${global:TEST_USER}`" --build-arg `"AGENT_WORKDIR=${global:TEST_AGENT_WORKDIR}`" --tag ${global:IMAGE_NAME} --file ./windows/${global:WINDOWSFLAVOR}/Dockerfile ."
+        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --target agent --build-arg `"VERSION=${global:TEST_VERSION}`" --build-arg `"JAVA_RELEASE=${global:JAVARELEASE}`" --build-arg `"WINDOWS_VERSION_TAG=${global:WINDOWSVERSIONTAG}`" --build-arg `"user=${global:TEST_USER}`" --build-arg `"AGENT_WORKDIR=${global:TEST_AGENT_WORKDIR}`" --tag ${global:IMAGE_NAME} --file ./windows/${global:WINDOWSFLAVOR}/Dockerfile ."
         $exitCode | Should -Be 0
 
         $exitCode, $stdout, $stderr = Run-Program 'docker' "run -d -it --name $global:CONTAINERNAME -P $global:IMAGE_NAME $global:CONTAINERSHELL"

--- a/tests/inbound-agent.Tests.ps1
+++ b/tests/inbound-agent.Tests.ps1
@@ -10,7 +10,7 @@ $GLOBAL:IMAGE_TAG = $imageItems[1]
 
 $items = $global:IMAGE_TAG.Split('-')
 # Remove the 'jdk' prefix (3 first characters)
-$global:JAVAMAJORVERSION = $items[0].Remove(0,3)
+$global:JAVARELEASE = $items[0].Remove(0,3)
 $global:WINDOWSFLAVOR = $items[1]
 $global:WINDOWSVERSIONTAG = $items[2]
 
@@ -35,7 +35,7 @@ CleanupNetwork('jnlp-network')
 
 Describe "[$global:IMAGE_NAME] build image" {
     It 'builds image' {
-        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --build-arg `"VERSION=${global:VERSION}`" --build-arg `"JAVA_RELEASE=${global:JAVAMAJORVERSION}`" --build-arg `"WINDOWS_VERSION_TAG=${global:WINDOWSVERSIONTAG}`" --tag=${global:IMAGE_TAG} --file ./windows/${global:WINDOWSFLAVOR}/Dockerfile ."
+        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --build-arg `"VERSION=${global:VERSION}`" --build-arg `"JAVA_RELEASE=${global:JAVARELEASE}`" --build-arg `"WINDOWS_VERSION_TAG=${global:WINDOWSVERSIONTAG}`" --tag=${global:IMAGE_TAG} --file ./windows/${global:WINDOWSFLAVOR}/Dockerfile ."
         $exitCode | Should -Be 0
     }
 }
@@ -117,7 +117,7 @@ Describe "[$global:IMAGE_NAME] custom build args" {
     }
 
     It 'builds image with arguments' {
-        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --build-arg `"VERSION=${TEST_VERSION}`" --build-arg `"JAVA_RELEASE=${global:JAVAMAJORVERSION}`" --build-arg `"WINDOWS_VERSION_TAG=${global:WINDOWSVERSIONTAG}`" --build-arg WINDOWS_FLAVOR=${global:WINDOWSFLAVOR} --build-arg CONTAINER_SHELL=${global:CONTAINERSHELL} --tag=${customImageName} --file=./windows/${global:WINDOWSFLAVOR}/Dockerfile ."
+        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --build-arg `"VERSION=${TEST_VERSION}`" --build-arg `"JAVA_RELEASE=${global:JAVARELEASE}`" --build-arg `"WINDOWS_VERSION_TAG=${global:WINDOWSVERSIONTAG}`" --build-arg WINDOWS_FLAVOR=${global:WINDOWSFLAVOR} --build-arg CONTAINER_SHELL=${global:CONTAINERSHELL} --tag=${customImageName} --file=./windows/${global:WINDOWSFLAVOR}/Dockerfile ."
         $exitCode | Should -Be 0
 
         $exitCode, $stdout, $stderr = Run-Program 'docker' "run --detach --tty --name $global:CONTAINERNAME $customImageName -Cmd $global:CONTAINERSHELL"
@@ -138,7 +138,7 @@ Describe "[$global:IMAGE_NAME] custom build args" {
 }
 
 Describe "[$global:IMAGE_NAME] passing JVM options (slow test)" {
-    It "shows the java version ${global:JAVAMAJORVERSION} with --show-version" {
+    It "shows the java version ${global:JAVARELEASE} with --show-version" {
         $exitCode, $stdout, $stderr = Run-Program 'docker' 'network create --driver nat jnlp-network'
         Start-NcatContainer -windowsVersionTag $global:WINDOWSVERSIONTAG -networkName 'jnlp-network'
 
@@ -154,7 +154,7 @@ Describe "[$global:IMAGE_NAME] passing JVM options (slow test)" {
         Start-Sleep -Seconds 20
         $exitCode, $stdout, $stderr = Run-Program 'docker' "logs $global:CONTAINERNAME"
         $exitCode | Should -Be 0
-        $stdout | Should -Match "OpenJDK Runtime Environment Temurin-${global:JAVAMAJORVERSION}"
+        $stdout | Should -Match "OpenJDK Runtime Environment Temurin-${global:JAVARELEASE}"
     }
 
     AfterAll {


### PR DESCRIPTION
Ref. https://github.com/jenkinsci/docker-agents/pull/1272#discussion_r3727360398

This PR only changes the naming of the "major java version" across our tools (bake file and windows tests) to ensure we get a coherent naming with the build arg. `JAVA_RELEASE` introduced in #1272 and the Adoptium API (see the `jdk*.yaml` updatecli manifest).