### PR TITLE
chore(pipeline): build JDKs sequentialy for Windows images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,9 @@ if (env.TAG_NAME) {
     }
 }
 
+// Specify java release(s) to build for Windows images
+def windowsJavaReleases = [21, 25]
+
 // Specify parallel stages
 // Linux: bake group(s) or target(s), see 'make list' or 'make listgroup-linux' output
 // Note: splitting Alpine and Debian targets to avoid 429 rate limit errors from Docker Hub
@@ -106,7 +109,11 @@ def parallelStages = [failFast: false]
                                     sh 'make "build-${IMAGE_TYPE}"'
                                 } else {
                                     // No multiarch Windows images
-                                    powershell './make.ps1 build'
+                                    windowsJavaReleases.each { javaRelease ->
+                                        withEnv(["JAVA_RELEASE_OVERRIDE=${javaRelease}"]) {
+                                            powershell './make.ps1 build -ImageType ${env:IMAGE_TYPE} -OverwriteDockerComposeFile'
+                                        }
+                                    }
                                 }
                             }
 
@@ -114,7 +121,11 @@ def parallelStages = [failFast: false]
                                 if (isUnix()) {
                                     sh 'make "test-${IMAGE_TYPE}"'
                                 } else {
-                                    powershell './make.ps1 test'
+                                    windowsJavaReleases.each { javaRelease ->
+                                        withEnv(["JAVA_RELEASE_OVERRIDE=${javaRelease}"]) {
+                                            powershell './make.ps1 test -ImageType ${env:IMAGE_TYPE} -OverwriteDockerComposeFile'
+                                        }
+                                    }
                                 }
                                 junit 'target/**/junit-results*.xml'
                             }
@@ -128,7 +139,11 @@ def parallelStages = [failFast: false]
                                 sh 'make "multiarchbuild-${IMAGE_TYPE}"'
                             } else {
                                 // No multiarch images for Windows, (re)building them here on both controllers
-                                powershell './make.ps1 build'
+                                windowsJavaReleases.each { javaRelease ->
+                                    withEnv(["JAVA_RELEASE_OVERRIDE=${javaRelease}"]) {
+                                        powershell './make.ps1 build -ImageType ${env:IMAGE_TYPE} -OverwriteDockerComposeFile'
+                                    }
+                                }
                             }
                             archiveArtifacts artifacts: 'target/build-result-metadata_*.json', allowEmptyArchive: true
                         }
@@ -149,7 +164,11 @@ def parallelStages = [failFast: false]
                                             sh 'make listgroup-linux | xargs -I {} make "publish-{}"'
                                         }
                                     } else {
-                                        powershell './make.ps1 publish'
+                                        windowsJavaReleases.each { javaRelease ->
+                                            withEnv(["JAVA_RELEASE_OVERRIDE=${javaRelease}"]) {
+                                                powershell './make.ps1 publish -ImageType ${env:IMAGE_TYPE} -OverwriteDockerComposeFile'
+                                            }
+                                        }
                                     }
                                 }
                                 archiveArtifacts artifacts: 'target/build-result-metadata_*.json', allowEmptyArchive: true

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -68,11 +68,16 @@ variable "WINDOWS_AGENT_TYPE_OVERRIDE" {
   default = ""
 }
 
+# Set this value to a specific version to override java release to build
+variable "JAVA_RELEASE_OVERRIDE" {
+  default = ""
+}
+
 ## Targets
 target "alpine" {
   matrix = {
     type          = agent_types_to_build
-    java_release  = java_releases_to_build
+    java_release  = java_releases(JAVA_RELEASE_OVERRIDE)
   }
   name       = "${type}_alpine_jdk${java_release}"
   target     = type
@@ -90,7 +95,7 @@ target "alpine" {
 target "debian" {
   matrix = {
     type          = agent_types_to_build
-    java_release  = java_releases_to_build
+    java_release  = java_releases(JAVA_RELEASE_OVERRIDE)
   }
   name       = "${type}_debian_jdk${java_release}"
   target     = type
@@ -108,7 +113,7 @@ target "debian" {
 target "rhel_ubi9" {
   matrix = {
     type          = agent_types_to_build
-    java_release  = java_releases_to_build
+    java_release  = java_releases(JAVA_RELEASE_OVERRIDE)
   }
   name       = "${type}_rhel_ubi9_jdk${java_release}"
   target     = type
@@ -126,7 +131,7 @@ target "rhel_ubi9" {
 target "nanoserver" {
   matrix = {
     type            = windowsagenttypes(WINDOWS_AGENT_TYPE_OVERRIDE)
-    java_release    = java_releases_to_build
+    java_release    = java_releases(JAVA_RELEASE_OVERRIDE)
     windows_version = windowsversions("nanoserver")
   }
   name       = "${type}_nanoserver-${windows_version}_jdk${java_release}"
@@ -145,7 +150,7 @@ target "nanoserver" {
 target "windowsservercore" {
   matrix = {
     type            = windowsagenttypes(WINDOWS_AGENT_TYPE_OVERRIDE)
-    java_release    = java_releases_to_build
+    java_release    = java_releases(JAVA_RELEASE_OVERRIDE)
     windows_version = windowsversions("windowsservercore")
   }
   name       = "${type}_windowsservercore-${windows_version}_jdk${java_release}"
@@ -195,6 +200,15 @@ function "orgrepo" {
 function "is_default_java_release" {
   params = [java_release]
   result = equal(default_java_release, java_release) ? true : false
+}
+
+# Return array of java releases to build
+# Can be overriden to a specific version
+function "java_releases" {
+  params = [override]
+  result = (notequal(override, "")
+    ? [override]
+  : java_releases_to_build)
 }
 
 ## Specific functions


### PR DESCRIPTION
Needed for:
- https://github.com/jenkinsci/docker-agents/pull/1315#issuecomment-5302431770
- https://github.com/jenkinsci/docker-agents/pull/1110#issuecomment-5169630080

Cleaner version of:
- https://github.com/jenkinsci/docker/pull/2392

Ref:
- https://github.com/jenkinsci/docker/issues/2382

### Testing done

```bash
# Listing all java release versions in Windows images
$ OS=windows ARCH=amd64 make list
agent_nanoserver-ltsc2022_jdk21
agent_nanoserver-ltsc2022_jdk25
agent_windowsservercore-ltsc2022_jdk21
agent_windowsservercore-ltsc2022_jdk25
inbound-agent_nanoserver-ltsc2022_jdk21
inbound-agent_nanoserver-ltsc2022_jdk25
inbound-agent_windowsservercore-ltsc2022_jdk21
inbound-agent_windowsservercore-ltsc2022_jdk25

# Listing only jdk21 version in Windows images
$ JAVA_RELEASE_OVERRIDE=21 OS=windows ARCH=amd64 make list
agent_nanoserver-ltsc2022_jdk21
agent_windowsservercore-ltsc2022_jdk21
inbound-agent_nanoserver-ltsc2022_jdk21
inbound-agent_windowsservercore-ltsc2022_jdk21

# Listing only jdk21 version in Linux images
$ JAVA_RELEASE_OVERRIDE=21 OS=linux ARCH=amd64 make list
agent_alpine_jdk21
agent_debian_jdk21
agent_rhel_ubi9_jdk21
inbound-agent_alpine_jdk21
inbound-agent_debian_jdk21
inbound-agent_rhel_ubi9_jdk21
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
