### PR TITLE
chore(windows): remove `OverwriteDockerComposeFile` obsolete parameter of make.ps1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,7 +107,7 @@ def parallelStages = [failFast: false]
                                     // No multiarch Windows images
                                     windowsJavaReleases.each { javaRelease ->
                                         withEnv(["JAVA_RELEASE_OVERRIDE=${javaRelease}"]) {
-                                            powershell './make.ps1 build -ImageType ${env:IMAGE_TYPE} -OverwriteDockerComposeFile'
+                                            powershell './make.ps1 build -ImageType ${env:IMAGE_TYPE}'
                                         }
                                     }
                                 }
@@ -119,7 +119,7 @@ def parallelStages = [failFast: false]
                                 } else {
                                     windowsJavaReleases.each { javaRelease ->
                                         withEnv(["JAVA_RELEASE_OVERRIDE=${javaRelease}"]) {
-                                            powershell './make.ps1 test -ImageType ${env:IMAGE_TYPE} -OverwriteDockerComposeFile'
+                                            powershell './make.ps1 test -ImageType ${env:IMAGE_TYPE}'
                                         }
                                     }
                                 }
@@ -137,7 +137,7 @@ def parallelStages = [failFast: false]
                                 // No multiarch images for Windows, (re)building them here on both controllers
                                 windowsJavaReleases.each { javaRelease ->
                                     withEnv(["JAVA_RELEASE_OVERRIDE=${javaRelease}"]) {
-                                        powershell './make.ps1 build -ImageType ${env:IMAGE_TYPE} -OverwriteDockerComposeFile'
+                                        powershell './make.ps1 build -ImageType ${env:IMAGE_TYPE}'
                                     }
                                 }
                             }
@@ -162,7 +162,7 @@ def parallelStages = [failFast: false]
                                     } else {
                                         windowsJavaReleases.each { javaRelease ->
                                             withEnv(["JAVA_RELEASE_OVERRIDE=${javaRelease}"]) {
-                                                powershell './make.ps1 publish -ImageType ${env:IMAGE_TYPE} -OverwriteDockerComposeFile'
+                                                powershell './make.ps1 publish -ImageType ${env:IMAGE_TYPE}'
                                             }
                                         }
                                     }

--- a/make.ps1
+++ b/make.ps1
@@ -11,8 +11,6 @@ Param(
     [String] $ImageType = 'nanoserver-ltsc2022',
     # Image build number
     [String] $BuildNumber = '1',
-    # Generate a docker compose file even if it already exists
-    [switch] $OverwriteDockerComposeFile = $false,
     # Print the build and publish command instead of executing them if set
     [switch] $DryRun = $false,
     # Pester version to install and use for tests
@@ -180,13 +178,9 @@ foreach($agentType in $AgentTypes) {
     $baseDockerCmd = 'docker-compose --file={0}' -f $dockerComposeFile
     $baseDockerBuildCmd = '{0} build --pull' -f $baseDockerCmd
 
-    # Generate the docker compose file if it doesn't exists or if the parameter OverwriteDockerComposeFile is set
-    if ((Test-Path $dockerComposeFile) -and -not $OverwriteDockerComposeFile) {
-        Write-Host "= PREPARE: The docker compose file '$dockerComposeFile' containing the $agentType image definitions already exists."
-    } else {
-        Write-Host "= PREPARE: Generate docker compose file '$dockerComposeFile' containing the $agentType image definitions."
-        Initialize-DockerComposeFile -AgentType $AgentType -ImageType $ImageType -DockerComposeFile $dockerComposeFile
-    }
+    # Generate the docker compose file (warning: will overwrite existing file)
+    Write-Host "= PREPARE: Generate docker compose file '$dockerComposeFile' containing the $agentType image definitions."
+    Initialize-DockerComposeFile -AgentType $AgentType -ImageType $ImageType -DockerComposeFile $dockerComposeFile
 
     if ($Target -eq 'build') {
         Write-Host '= PREPARE: List of images and tags to be processed:'


### PR DESCRIPTION
This change removes the `OverwriteDockerComposeFile` parameter of make.ps1, initially designed to avoid mistake when working locally on generated docker compose file, a niche use case kinda obsolete now (if it ever served anyone else than me '^^).

This removal allows a simplification of make.ps1 calls in Jenkinsfile.

### Testing done

CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
